### PR TITLE
Make taglib safe-string compatible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please read the COPYING file before using this software.
 Prerequisites
 --------------
 
-* ocaml >= 4.00.1
+* ocaml >= 4.02.0
 * Taglib >= 1.8
 * findlib >= 1.3.3
 

--- a/m4/ocaml.m4
+++ b/m4/ocaml.m4
@@ -21,9 +21,9 @@ AC_DEFUN([AC_PROG_OCAML],
 
   OCAMLVERSION=`$OCAMLC -v | sed -n -e 's|.*version* *\(.*\)$|\1|p'`
   AC_MSG_RESULT([OCaml version is $OCAMLVERSION])
-  # Check if version is >= 4.06.0
+  # Check if version is >= 4.02.0
   AC_MSG_CHECKING([if ocaml compiler supports first-class modules])
-  AS_VERSION_COMPARE([$OCAMLVERSION],[4.06.0],[],[OCAML_HAS_FIRST_CLASS_MODULES="yes"],[OCAML_HAS_FIRST_CLASS_MODULES="yes"])
+  AS_VERSION_COMPARE([$OCAMLVERSION],[4.02.0],[],[OCAML_HAS_FIRST_CLASS_MODULES="yes"],[OCAML_HAS_FIRST_CLASS_MODULES="yes"])
   if test -n "${OCAML_HAS_FIRST_CLASS_MODULES}"; then
     AC_MSG_RESULT([yes])
   else

--- a/m4/ocaml.m4
+++ b/m4/ocaml.m4
@@ -21,9 +21,9 @@ AC_DEFUN([AC_PROG_OCAML],
 
   OCAMLVERSION=`$OCAMLC -v | sed -n -e 's|.*version* *\(.*\)$|\1|p'`
   AC_MSG_RESULT([OCaml version is $OCAMLVERSION])
-  # Check if version is >= 3.12.0
+  # Check if version is >= 4.06.0
   AC_MSG_CHECKING([if ocaml compiler supports first-class modules])
-  AS_VERSION_COMPARE([$OCAMLVERSION],[3.12.0],[],[OCAML_HAS_FIRST_CLASS_MODULES="yes"],[OCAML_HAS_FIRST_CLASS_MODULES="yes"])
+  AS_VERSION_COMPARE([$OCAMLVERSION],[4.06.0],[],[OCAML_HAS_FIRST_CLASS_MODULES="yes"],[OCAML_HAS_FIRST_CLASS_MODULES="yes"])
   if test -n "${OCAML_HAS_FIRST_CLASS_MODULES}"; then
     AC_MSG_RESULT([yes])
   else

--- a/src/taglib.ml
+++ b/src/taglib.ml
@@ -276,9 +276,9 @@ struct
       parse_tag (grab_tag t) h ;
       t
    
-    external render : tag -> string = "caml_taglib_id3v2_render"
+    external render : tag -> bytes = "caml_taglib_id3v2_render"
 
-    let render t = render (grab_tag t)
+    let render t = Bytes.to_string (render (grab_tag t))
 
     external attach_frame : tag -> string -> string -> unit = "caml_taglib_id3v2_attach_frame"
 

--- a/src/taglib_stubs.cc
+++ b/src/taglib_stubs.cc
@@ -579,8 +579,11 @@ CAMLprim value caml_taglib_id3v2_render(value t)
   ByteVector r = tag->render();
 
   ret = caml_alloc_string(r.size());
+#ifdef CAML_SAFE_STRING
   memcpy(Bytes_val(ret),r.data(),r.size());
-
+#else
+  memcpy(String_val(ret),r.data(),r.size());
+#endif
   CAMLreturn(ret);
 }
 

--- a/src/taglib_stubs.cc
+++ b/src/taglib_stubs.cc
@@ -313,7 +313,7 @@ CAMLprim value caml_taglib_tag_get_string(value t, value name)
   CAMLparam2(t,name);
   CAMLlocal1(ans);
   const Tag *tag = Taglib_tag_val(t) ;
-  char *s = String_val(name);
+  const char *s = String_val(name);
   String tmp = String::null;
 
   if (!strcmp(s,"title"))
@@ -340,7 +340,7 @@ CAMLprim value caml_taglib_tag_get_int(value t, value name)
 {
   CAMLparam2(t,name);
   const Tag *tag = Taglib_tag_val(t) ;
-  char *s = String_val(name);
+  const char *s = String_val(name);
   int tmp;
 
     if (!strcmp(s,"year"))
@@ -400,7 +400,7 @@ CAMLprim value caml_taglib_file_set_properties(value f, value properties)
   CAMLlocal1(caml_values);
   File *file = Taglib_file_val(f);
   PropertyMap props;
-  char *caml_key, *caml_val;
+  const char *caml_key, *caml_val;
   StringList *values;
   String *key, *val;
   int i,j;
@@ -441,7 +441,7 @@ CAMLprim value caml_taglib_tag_set_string(value t, value name, value v)
 {
   CAMLparam3(t,name, v);
   Tag *tag = Taglib_tag_val(t) ;
-  char *s = String_val(name);
+  const char *s = String_val(name);
   const char *x = String_val(v) ;
 
     if (!strcmp(s,"title"))
@@ -464,7 +464,7 @@ CAMLprim value caml_taglib_tag_set_int(value t, value name, value v)
 {
   CAMLparam3(t,name, v);
   Tag *tag = Taglib_tag_val(t) ;
-  char *s = String_val(name);
+  const char *s = String_val(name);
   int x = Int_val(v) ;
 
     if (!strcmp(s,"year"))
@@ -481,7 +481,7 @@ CAMLprim value caml_taglib_audioproperties_get_int(value p, value name)
 {
   CAMLparam2(p,name);
   const AudioProperties *prop = Taglib_audioproperties_val(p) ;
-  char *s = String_val(name);
+  const char *s = String_val(name);
   int tmp;
 
     if (!strcmp(s,"length"))
@@ -564,7 +564,7 @@ CAMLprim value caml_taglib_id3v2_parse_tag(value t, value h)
 {
   CAMLparam2(t,h);
   myId3v2 *tag = Id3v2_tag_val(t);
-  char *s = String_val(h);
+  const char *s = String_val(h);
   TagLib::uint size = ID3v2::Header::size();
 
   tag->doParse(ByteVector(s+size,caml_string_length(h)-size));
@@ -579,7 +579,7 @@ CAMLprim value caml_taglib_id3v2_render(value t)
   ByteVector r = tag->render();
 
   ret = caml_alloc_string(r.size());
-  memcpy(String_val(ret),r.data(),r.size());
+  memcpy(Bytes_val(ret),r.data(),r.size());
 
   CAMLreturn(ret);
 }


### PR DESCRIPTION
Change `char *` to `const char *` for extracted String values and changed the return value of the caml_taglib_id3v2_render function to bytes instead of strings. Unfortunately this requires that the OCaml version is larger than 4.06.

I think this could be avoided if the result of `ByteVector r = tag->render()` is guaranteed to be a valid C string.